### PR TITLE
ensure that mocked version of library exposes flush()

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,8 +73,8 @@ function shutDown() {
 process.on("SIGTERM", shutDown);
 
 module.exports = {
-  initialize,
   flush,
-  isEnabled,
   getAllFlags
+  initialize,
+  isEnabled,
 };

--- a/mock/index.js
+++ b/mock/index.js
@@ -17,6 +17,10 @@ function initialize() {
   return true;
 }
 
+function flush() {
+  return true;
+}
+
 function reset(flags) {
   flagStore = setFlagDefaults(flags);
 }
@@ -30,9 +34,12 @@ function getAllFlags() {
 }
 
 module.exports = {
+  flush,
+  getAllFlags
   initialize,
   isEnabled,
-  getAllFlags,
+
+  // mock-only exports
   forceFlag,
   reset
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-featureflags",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "A simple wrapper library for accessing feature flags from LaunchDarkly",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
The mocked version of module isn't api-compatible: any tests running code that attempts to invoke `flush()` would fail.